### PR TITLE
Provide route to get user by email address

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -80,9 +80,20 @@ func (h Handlers) LastActiveUsers(w http.ResponseWriter, r *http.Request) {
 }
 
 // GetUser delivers user for id
-func (h Handlers) GetUser(w http.ResponseWriter, r *http.Request) {
-	id, _ := strconv.Atoi(mux.Vars(r)["id"])
-	user, err := h.GetSingleUser(id)
+// func (h Handlers) GetUser(w http.ResponseWriter, r *http.Request) {
+// 	id, _ := strconv.Atoi(mux.Vars(r)["id"])
+// 	user, err := h.GetSingleUser(id)
+// 	if err != nil {
+// 		printDbError(w)
+// 	} else {
+// 		printJSON(w, &UserResponse{User: user})
+// 	}
+// }
+
+// GetUserByEmail delivers user for email
+func (h Handlers) GetUserByEmail(w http.ResponseWriter, r *http.Request) {
+	email, _ := mux.Vars(r)["email"]
+	user, err := h.GetSingleUserByIEmail(email)
 	if err != nil {
 		printDbError(w)
 	} else {

--- a/routes.go
+++ b/routes.go
@@ -48,11 +48,17 @@ func GetRoutes(h *Handlers) Routes {
 			"/api/users/lastactive",
 			h.LastActiveUsers,
 		},
+		// Route{
+		// 	"GetUserById",
+		// 	"GET",
+		// 	"/api/users/{id}",
+		// 	h.GetUser,
+		// },
 		Route{
-			"LastActiveUsers",
+			"GetUserByEmail",
 			"GET",
-			"/api/users/{id}",
-			h.GetUser,
+			"/api/users/{email}",
+			h.GetUserByEmail,
 		},
 		Route{
 			"CreateAuth0User",

--- a/user.go
+++ b/user.go
@@ -171,6 +171,49 @@ func (h Handlers) GetSingleUser(id int) (User, error) {
 
 }
 
+// GetSingleUserByIEmail returns user
+func (h Handlers) GetSingleUserByIEmail(email string) (User, error) {
+	var user User
+	if err := h.DB.QueryRow(`
+		SELECT
+			id, 
+			COALESCE(username, '') as username,
+			email, lastname, firstname, mobile,
+			street, zip, city, 
+			COALESCE(date_of_birth, '') as date_of_birth,			
+			COALESCE(date_of_entry, '') as date_of_entry,
+			COALESCE(date_of_exit, '') as date_of_exit,
+			COALESCE(group_comment, '') as group_comment,
+			state, credit, credit_date, credit_comment,						
+			COALESCE(last_login, '') as last_login
+		FROM users
+		WHERE email = ?`, email).Scan(
+		&user.ID,
+		&user.Username,
+		&user.Email,
+		&user.Lastname,
+		&user.Firstname,
+		&user.Mobile,
+		&user.Street,
+		&user.ZIP,
+		&user.City,
+		&user.DateOfBirth,
+		&user.DateOfEntry,
+		&user.DateOfExit,
+		&user.GroupComment,
+		&user.State,
+		&user.Credit,
+		&user.CreditDate,
+		&user.CreditComment,
+		&user.LastLogin,
+	); err != nil {
+		fmt.Println(err)
+		return user, err
+	}
+	return user, nil
+
+}
+
 // UpdateUserData updates user
 func (h Handlers) UpdateUserData(user User) error {
 	_, err := h.DB.Exec(


### PR DESCRIPTION
Neither the database id is stored on auth provider nor the auth provider user
id is stored in database. To link auth provider and database user data we use
the email address.